### PR TITLE
add linux makefile for wine games

### DIFF
--- a/Makefile.linuxMinGW
+++ b/Makefile.linuxMinGW
@@ -1,0 +1,20 @@
+REV=$(shell sh -c 'date +"%Y,%m,%d"')
+
+# Define the compilers and resource compiler for mingw
+CC=i686-w64-mingw32-gcc
+WINDRES=i686-w64-mingw32-windres
+
+# Define the include and library paths for mingw
+MINGW_INCLUDE_PATH=/usr/i686-w64-mingw32/include
+MINGW_LIB_PATH=/usr/i686-w64-mingw32/lib
+
+all: ogg-winmm.dll
+
+ogg-winmm.rc.o: ogg-winmm.rc.in
+	sed 's/__REV__/$(REV)/' ogg-winmm.rc.in | $(WINDRES) -O coff -o ogg-winmm.rc.o
+
+ogg-winmm.dll: ogg-winmm.c player.c player.h stubs.c stub.h ogg-winmm.def ogg-winmm.rc.o
+	$(CC) -m32 -std=gnu99 -static-libgcc -Wl,--enable-stdcall-fixup,--gc-sections -s -O2 -shared -o winmm.dll ogg-winmm.c player.c stubs.c ogg-winmm.def ogg-winmm.rc.o -Ilibs/include -I$(MINGW_INCLUDE_PATH) -Llibs -L$(MINGW_LIB_PATH) -lwinmm -l:libvorbisfile.a -l:libvorbis.a -l:libogg.a
+
+clean:
+	rm -f winmm.dll ogg-winmm.rc.o


### PR DESCRIPTION
Hi,

Thank you for providing the resources to run a Tomb Raider 2 map from trle.net with Wine on Linux. This has been incredibly helpful.

I have created a Makefile specifically for Linux environments using MinGW. On Linux, MinGW GCC is typically located on its own path and uses a specific naming convention, such as i686-w64-mingw32-gcc.

To facilitate building from your repository in the future, I suggest including this Makefile. The command to use it would be:
```
make -f Makefile.linuxMinGW
```
This addition will not interfere with your existing build process.

Best regards,

Martin Bångens