### PR TITLE
Fix issues with mciSendString usage

### DIFF
--- a/ogg-winmm.c
+++ b/ogg-winmm.c
@@ -673,13 +673,13 @@ MCIERROR WINAPI fake_mciSendStringA(LPCSTR cmd, LPSTR ret, UINT cchReturn, HANDL
 		{
 			sprintf(alias_s, "%s", tmp_s+1);
 		}
-		fake_mciSendCommandA(MAGIC_DEVICEID, MCI_OPEN, 0, (DWORD_PTR)NULL);
+		// fake_mciSendCommandA(MAGIC_DEVICEID, MCI_OPEN, 0, (DWORD_PTR)NULL);
 		return 0;
 	}
 
 	if (strstr(cmdbuf, "open cdaudio"))
 	{
-		fake_mciSendCommandA(MAGIC_DEVICEID, MCI_OPEN, 0, (DWORD_PTR)NULL);
+		// fake_mciSendCommandA(MAGIC_DEVICEID, MCI_OPEN, 0, (DWORD_PTR)NULL);
 		return 0;
 	}
 


### PR DESCRIPTION
Fixes #25 

Calling `fake_mciSendCommandA(MAGIC_DEVICEID, MCI_OPEN, 0, (DWORD_PTR)NULL);` with the last parameter null causes a crash.

Also add support for MM:SS:FF play format (used by Ignition-1996).